### PR TITLE
Add Velt for BlockNote to Plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ The open source Block-Based React rich text editor. Easily add a modern text edi
 - [blocknote-mermaid](https://github.com/defensestation/blocknote-mermaid) — Mermaid feature for BlockNote
 - [blocknote-code](https://github.com/defensestation/blocknote-code) - Code feature for BlockNote
 - [blocknote-draw](https://github.com/rangelkoli/blocknote-draw) - Drawing canvas for BlockNote.
+- [Velt for BlockNote](https://sample-apps-blocknote-react-crdt-de.vercel.app) - Collaboration layer adding comments, presence, and Yjs-based real-time editing to BlockNote.
 
 ## Projects Using BlockNote
 


### PR DESCRIPTION
Adds **Velt for BlockNote** to the Plugins section.

Velt adds comments, presence, and Yjs-based real-time collaborative editing to BlockNote.

- Live demo: https://sample-apps-blocknote-react-crdt-de.vercel.app
- Docs: https://velt.dev/docs/realtime-collaboration/crdt/setup/blocknote
- Source: https://github.com/velt-js/sample-apps/tree/main/apps/react/crdt/text-editors/blocknote/blocknote-demo

Per the contributing guidelines: new branch, appended to the bottom of Plugins, format `- [name](link) - Description.`